### PR TITLE
HUD Interaction Widget Added

### DIFF
--- a/Source/HorrorGame/Public/interaction_System.h
+++ b/Source/HorrorGame/Public/interaction_System.h
@@ -8,6 +8,7 @@
 #include "interaction_System.generated.h"
 
 class Afirst_Person_Character;
+class UWidgetComponent;
 
 UCLASS()
 class HORRORGAME_API Ainteraction_System : public AActor
@@ -17,6 +18,8 @@ class HORRORGAME_API Ainteraction_System : public AActor
 public:	
 	// Sets default values for this actor's properties
 	Ainteraction_System();
+
+	virtual void Tick(float DeltaTime) override;
 
 	UFUNCTION()
 	void Interact(Afirst_Person_Character* Character);
@@ -56,12 +59,13 @@ private:
 	void CompleteLoopDoor(Afirst_Person_Character* Character, AActor* HitActor);
 
 	void TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor);
-
-
+	void WidgetPrompt(Afirst_Person_Character* Character, AActor* HitActor, bool Visibility);
 
 	// Map of tag -> function pointer
 	TMap<FName, void (Ainteraction_System::*)(Afirst_Person_Character*, AActor*)> Interaction_Functions;
-
 	void InitInteractionFunctionMap();
+
+	AActor* LineTraceFromCamera(Afirst_Person_Character* Character, FHitResult& Hit);
+	AActor* LastHitActor = nullptr;
 
 };


### PR DESCRIPTION
- Made it so that the player should be line tracing per tick
- Made the line trace feature a function to reduce redundancy
- Made a widget prompt function that should hover by any interactable objects
- Widget prompt only appears when the player is within range and disappear otherwise
- Widget prompt is also made so that it will always be facing the direction of the player's camera and rotate alone with it