### PR TITLE
Inventory System (Code-based, UI later to be added)

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -83,12 +83,14 @@ DoubleClickTime=0.200000
 +ActionMappings=(ActionName="InteractTest",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=E)
 +ActionMappings=(ActionName="PauseGame",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=Escape)
 +ActionMappings=(ActionName="ToggleFlashlight",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=F)
++ActionMappings=(ActionName="DropItem",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=G)
 +AxisMappings=(AxisName="Horizontal",Scale=1.000000,Key=D)
 +AxisMappings=(AxisName="Horizontal",Scale=-1.000000,Key=A)
 +AxisMappings=(AxisName="Vertical",Scale=1.000000,Key=W)
 +AxisMappings=(AxisName="Vertical",Scale=-1.000000,Key=S)
 +AxisMappings=(AxisName="SideRotation",Scale=1.000000,Key=MouseX)
 +AxisMappings=(AxisName="UpDownRotation",Scale=1.000000,Key=MouseY)
++AxisMappings=(AxisName="ScrollInventory",Scale=1.000000,Key=MouseWheelAxis)
 DefaultPlayerInputClass=/Script/EnhancedInput.EnhancedPlayerInput
 DefaultInputComponentClass=/Script/EnhancedInput.EnhancedInputComponent
 DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.DefaultVirtualJoysticks

--- a/Source/HorrorGame/Private/first_Person_Character.cpp
+++ b/Source/HorrorGame/Private/first_Person_Character.cpp
@@ -52,6 +52,7 @@ Afirst_Person_Character::Afirst_Person_Character()
     Flashlight->SetInnerConeAngle(20.0f);
     Flashlight->SetOuterConeAngle(35.0f);
     Flashlight->SetAttenuationRadius(1000.0f);
+    bFlashlightOn = false;
 
     //basic movements speeds
     DefaultMaxWalkingSpeed = 150.0f;
@@ -279,6 +280,8 @@ void Afirst_Person_Character::SetupPlayerInputComponent(UInputComponent* PlayerI
 
     // FLASHLIGHT INPUT (f)
     PlayerInputComponent->BindAction("ToggleFlashlight", IE_Pressed, this, &Afirst_Person_Character::ToggleFlashlight);
+    PlayerInputComponent->BindAction("DropItem", IE_Pressed, this, &Afirst_Person_Character::DropCurrentItem);
+    PlayerInputComponent->BindAxis("ScrollInventory", this, &Afirst_Person_Character::ScrollInventory);
 
     // PAUSE MENU INPUT (Escape)
     PlayerInputComponent->BindAction("PauseGame", IE_Pressed, this, &Afirst_Person_Character::TogglePause);
@@ -302,12 +305,84 @@ void Afirst_Person_Character::Vertic_Move(float value)
 
 void Afirst_Person_Character::ToggleFlashlight()
 {
-    if (!bHasFlashlight || !Flashlight) return;
+    if (CurrentItemTag == "PickupFlashlight")
+    {
+        bFlashlightOn = !bFlashlightOn;
+        Flashlight->SetVisibility(bFlashlightOn);
+        UE_LOG(LogTemp, Log, TEXT("Flashlight %s"), bFlashlightOn ? TEXT("ON") : TEXT("OFF"));
+    }
+    
+    else if (bFlashlightOn)
+    {
+        bFlashlightOn = false;
+        Flashlight->SetVisibility(false);
+        UE_LOG(LogTemp, Log, TEXT("Flashlight forced OFF because it's not being held"));
+    }
+}
 
-    bFlashlightOn = !bFlashlightOn;
-    Flashlight->SetVisibility(bFlashlightOn);
+void Afirst_Person_Character::DropCurrentItem()
+{
+    if (!CurrentItem) return;
 
-    UE_LOG(LogTemp, Log, TEXT("Flashlight toggled: %s"), bFlashlightOn ? TEXT("On") : TEXT("Off"));
+    FVector SpawnLocation = GetActorLocation() + GetActorForwardVector() * 150.f;
+    FRotator SpawnRotation = GetActorRotation();
+
+    UWorld* World = GetWorld();
+    if (World)
+    {
+        FActorSpawnParameters SpawnParams;
+        AActor* SpawnedActor = World->SpawnActor<AActor>(CurrentItem, SpawnLocation, SpawnRotation, SpawnParams);
+        SpawnedActor->SetActorScale3D(StoredItemScale);
+
+        Inventory.RemoveAt(CurrentIndex);
+        InventoryTags.RemoveAt(CurrentIndex);
+
+        if (Inventory.Num() > 0)
+        {
+            CurrentIndex = CurrentIndex % Inventory.Num();
+            CurrentItem = Inventory[CurrentIndex];
+            CurrentItemTag = InventoryTags[CurrentIndex];
+        }
+        else
+        {
+            CurrentIndex = 0;
+            CurrentItem = nullptr;
+            CurrentItemTag = NAME_None;
+        }
+
+        ToggleFlashlight();
+    }
+}
+
+void Afirst_Person_Character::ScrollInventory(float AxisValue)
+{
+    if (Inventory.Num() == 0 || FMath::IsNearlyZero(AxisValue)) return;
+
+    int32 TotalSlots = Inventory.Num() + 1;
+
+    CurrentIndex = (CurrentIndex + (AxisValue > 0 ? 1 : -1) + TotalSlots) % TotalSlots;
+
+    if (CurrentIndex == Inventory.Num())
+    {
+        CurrentItem = nullptr;
+        CurrentItemTag = NAME_None;
+        UE_LOG(LogTemp, Log, TEXT("Held item: None"));
+    }
+    else 
+    {
+        CurrentItem = (Inventory.IsValidIndex(CurrentIndex)) ? Inventory[CurrentIndex] : nullptr; 
+        CurrentItemTag = InventoryTags.IsValidIndex(CurrentIndex) ? InventoryTags[CurrentIndex] : NAME_None;
+        if (CurrentItem)
+        {
+            UE_LOG(LogTemp, Log, TEXT("Held item: %s"), *CurrentItem->GetName());
+        }
+        else
+        {
+            UE_LOG(LogTemp, Warning, TEXT("Held item is null (unexpected)"));
+        }
+    }
+    
+    ToggleFlashlight();
 }
 
 void Afirst_Person_Character::TogglePause()

--- a/Source/HorrorGame/Private/interaction_System.cpp
+++ b/Source/HorrorGame/Private/interaction_System.cpp
@@ -46,7 +46,6 @@ void Ainteraction_System::Tick(float DeltaTime)
     }
 
     LastHitActor = Current;
-    UE_LOG(LogTemp, Log, TEXT("Tick Trace hit: nothing"));
 }
 
 AActor* Ainteraction_System::LineTraceFromCamera(Afirst_Person_Character* Character, FHitResult& Hit)
@@ -73,7 +72,7 @@ void Ainteraction_System::InitInteractionFunctionMap()
     Interaction_Functions.Add(FName(TEXT("ExitDoor")), &Ainteraction_System::CompleteLoopDoor);
     Interaction_Functions.Add(FName(TEXT("Loop1Key")), &Ainteraction_System::CollectLoop1Key);
     Interaction_Functions.Add("TeleportToMainRoom", &Ainteraction_System::TeleportUsingDataTable); // uses the DataTable
-    Interaction_Functions.Add(FName(TEXT("PickupFlashlight")), &Ainteraction_System::PickupFlashlight);
+    Interaction_Functions.Add(FName(TEXT("Pickup_Object")), &Ainteraction_System::Pickup_Object);
 
 }
 
@@ -116,7 +115,7 @@ void Ainteraction_System::Perform_Interaction(Afirst_Person_Character* Character
         if (Row)
         {
             const FName& FunctionName = Row->Interactable_Function;
-
+            UE_LOG(LogTemp, Log, TEXT("Found function: %s"), *FunctionName.ToString());
             if (Interaction_Functions.Contains(FunctionName))
             {
                 UE_LOG(LogTemp, Log, TEXT("Performing interaction for tag '%s' using function '%s'"), *Tag.ToString(), *FunctionName.ToString());
@@ -154,31 +153,31 @@ void Ainteraction_System::WidgetPrompt(Afirst_Person_Character* Character, AActo
     }
 }
 
-void Ainteraction_System::PickupFlashlight(Afirst_Person_Character* Character, AActor* HitActor)
+
+void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AActor* HitActor)
 {
     if (!Character || !HitActor) return;
 
-    Character->bHasFlashlight = true;
+    TSubclassOf<AActor> Item = HitActor->GetClass();
+    FName Tag = HitActor->Tags.IsValidIndex(0) ? HitActor->Tags[0] : NAME_None;
+    Character->StoredItemScale = HitActor->GetActorScale3D();
 
-    if (Character->Flashlight)
-    {
-        Character->Flashlight->SetVisibility(false);
-        Character->bFlashlightOn = false;
-    }
+    Character->Inventory.Add(Item);
+    Character->InventoryTags.Add(Tag);
 
-    HitActor->Destroy();
-    UE_LOG(LogTemp, Log, TEXT("Flashlight picked up."));
+    Character->CurrentItem = Item;
+    Character->CurrentItemTag = Tag;
+    Character->CurrentIndex = Character->Inventory.Num() - 1;
+
+    UE_LOG(LogTemp, Log, TEXT("Item '%s' added to inventory."), *HitActor->GetName());
 
     UHorrorGameInstance* GI = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(Character));
     if (GI && HitActor->Tags.Num() > 0)
     {
         GI->MarkTagInteracted(HitActor->Tags[0]);
     }
-}
 
-void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AActor* HitActor)
-{
-    UE_LOG(LogTemp, Log, TEXT("Picked up an object!"));
+    HitActor->Destroy();
 }
 
 void Ainteraction_System::TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor)

--- a/Source/HorrorGame/Public/first_Person_Character.h
+++ b/Source/HorrorGame/Public/first_Person_Character.h
@@ -55,16 +55,28 @@ public:
     float TeleportDelayTime = 0.6f;
 
     // FLASHLIGHT FEATURE
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
     class USpotLightComponent* Flashlight;
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
-    bool bHasFlashlight = false;
+    bool bFlashlightOn;
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
-    bool bFlashlightOn = false;
+    // INVENTORY SYSTEM
+    UPROPERTY()
+    TArray<TSubclassOf<AActor>> Inventory;
+
+    UPROPERTY()
+    TArray<FName> InventoryTags;
+
+    UPROPERTY()
+    FVector StoredItemScale;
+    
+    FName CurrentItemTag = NAME_None;
+    TSubclassOf<AActor> CurrentItem = nullptr;
+    int32 CurrentIndex = 0;
 
     void ToggleFlashlight();
+    void DropCurrentItem();
+    void ScrollInventory(float Value);
 
 private:
     // FOV CAMERA TRANSITION FEATURE

--- a/Source/HorrorGame/Public/interaction_System.h
+++ b/Source/HorrorGame/Public/interaction_System.h
@@ -57,7 +57,6 @@ private:
 	void View_Note(Afirst_Person_Character* Character, AActor* HitActor);
 	void CollectLoop1Key(Afirst_Person_Character* Character, AActor* HitActor);
 	void CompleteLoopDoor(Afirst_Person_Character* Character, AActor* HitActor);
-	void PickupFlashlight(Afirst_Person_Character* Character, AActor* HitActor);
 
 	void TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor);
 	void WidgetPrompt(Afirst_Person_Character* Character, AActor* HitActor, bool Visibility);


### PR DESCRIPTION
- Added an Inventory system to the game by using an array
- The player always start with an empty inventory
- When picking up an object, player should still be able to switch off to holding nothing
- Player can only use the item that they are currently holding
- By pressing G, the player can drop the item they are currently holding back into the world with the same size it was in the world (for now it floats but can be fixed by adding physics later)
- By using scroll wheel up and down, the player can cycle through the inventory
- Integrated the previous flashlight feature with the new inventory system
- Bug fixed many crashes along the way of making the feature