### PR TITLE
Release V6

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -82,6 +82,7 @@ DoubleClickTime=0.200000
 +ActionMappings=(ActionName="Crouch",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=LeftControl)
 +ActionMappings=(ActionName="InteractTest",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=E)
 +ActionMappings=(ActionName="PauseGame",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=Escape)
++ActionMappings=(ActionName="ToggleFlashlight",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=F)
 +AxisMappings=(AxisName="Horizontal",Scale=1.000000,Key=D)
 +AxisMappings=(AxisName="Horizontal",Scale=-1.000000,Key=A)
 +AxisMappings=(AxisName="Vertical",Scale=1.000000,Key=W)

--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -83,12 +83,14 @@ DoubleClickTime=0.200000
 +ActionMappings=(ActionName="InteractTest",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=E)
 +ActionMappings=(ActionName="PauseGame",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=Escape)
 +ActionMappings=(ActionName="ToggleFlashlight",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=F)
++ActionMappings=(ActionName="DropItem",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=G)
 +AxisMappings=(AxisName="Horizontal",Scale=1.000000,Key=D)
 +AxisMappings=(AxisName="Horizontal",Scale=-1.000000,Key=A)
 +AxisMappings=(AxisName="Vertical",Scale=1.000000,Key=W)
 +AxisMappings=(AxisName="Vertical",Scale=-1.000000,Key=S)
 +AxisMappings=(AxisName="SideRotation",Scale=1.000000,Key=MouseX)
 +AxisMappings=(AxisName="UpDownRotation",Scale=1.000000,Key=MouseY)
++AxisMappings=(AxisName="ScrollInventory",Scale=1.000000,Key=MouseWheelAxis)
 DefaultPlayerInputClass=/Script/EnhancedInput.EnhancedPlayerInput
 DefaultInputComponentClass=/Script/EnhancedInput.EnhancedInputComponent
 DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.DefaultVirtualJoysticks

--- a/Source/HorrorGame/Private/HorrorGameInstance.cpp
+++ b/Source/HorrorGame/Private/HorrorGameInstance.cpp
@@ -2,6 +2,7 @@
 
 #include "HorrorGameInstance.h"
 #include "HorrorSaveGame.h"
+#include "first_Person_Character.h"
 #include "Kismet/GameplayStatics.h"
 
 // all logic in header
@@ -28,8 +29,19 @@ void UHorrorGameInstance::SaveGameProgress()
     SaveGameInstance->bLoop5Complete = bLoop5Complete;
     SaveGameInstance->bLoop6Complete = bLoop6Complete;
 
-    const FString SlotName = TEXT("HorrorSaveSlot");
+    APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+    if (PC)
+    {
+        Afirst_Person_Character* Player = Cast<Afirst_Person_Character>(PC->GetPawn());
+        if (Player)
+        {
+            SaveGameInstance->PlayerLocation = Player->GetActorLocation();
+            SaveGameInstance->PlayerRotation = Player->GetActorRotation();
+        }
+    }
+    SaveGameInstance->InteractedTags = InteractedTags.Array();
 
+    const FString SlotName = TEXT("HorrorSaveSlot");
     bool bSuccess = UGameplayStatics::SaveGameToSlot(SaveGameInstance, SlotName, 0);
     if (bSuccess)
     {
@@ -77,6 +89,19 @@ bool UHorrorGameInstance::LoadGameProgress()
     bLoop4Complete = LoadedGame->bLoop4Complete;
     bLoop5Complete = LoadedGame->bLoop5Complete;
     bLoop6Complete = LoadedGame->bLoop6Complete;
+
+    InteractedTags = TSet<FName>(LoadedGame->InteractedTags);
+
+    APlayerController* PC = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+    if (PC)
+    {
+        Afirst_Person_Character* Player = Cast<Afirst_Person_Character>(PC->GetPawn());
+        if (Player)
+        {
+            Player->SetActorLocation(LoadedGame->PlayerLocation);
+            Player->SetActorRotation(LoadedGame->PlayerRotation);
+        }
+    }
 
     UE_LOG(LogTemp, Warning, TEXT("Game Loaded: Loop = %d | L1 = %s | L2 = %s | L3 = %s"),
         CurrentLoopIndex,

--- a/Source/HorrorGame/Private/HorrorGameInstance.cpp
+++ b/Source/HorrorGame/Private/HorrorGameInstance.cpp
@@ -37,6 +37,10 @@ void UHorrorGameInstance::SaveGameProgress()
         {
             SaveGameInstance->PlayerLocation = Player->GetActorLocation();
             SaveGameInstance->PlayerRotation = Player->GetActorRotation();
+
+            // save flashlight battery state
+            SaveGameInstance->SavedBatteryLevel = Player->CurrentBattery;
+            SaveGameInstance->bHasPickedUpFlashlight = Player->bHasPickedUpFlashlight;
         }
     }
     SaveGameInstance->InteractedTags = InteractedTags.Array();
@@ -100,6 +104,10 @@ bool UHorrorGameInstance::LoadGameProgress()
         {
             Player->SetActorLocation(LoadedGame->PlayerLocation);
             Player->SetActorRotation(LoadedGame->PlayerRotation);
+
+            // restore flashlight battery state
+            Player->CurrentBattery = LoadedGame->SavedBatteryLevel;
+            Player->bHasPickedUpFlashlight = LoadedGame->bHasPickedUpFlashlight;
         }
     }
 

--- a/Source/HorrorGame/Private/first_Person_Character.cpp
+++ b/Source/HorrorGame/Private/first_Person_Character.cpp
@@ -174,6 +174,11 @@ void Afirst_Person_Character::BeginPlay()
                 {
                     PC->PlayerCameraManager->StartCameraFade(1.f, 0.f, 1.0f, FLinearColor::Black, false, true);
                 }, 0.1f, false); // change this so user waits 2 seconds on a black screen 
+            UHorrorGameInstance* GI = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(this));
+            if (GI)
+            {
+                GI->LoadGameProgress(); // this will auto-apply location + flags
+            }
         }
     }
 }

--- a/Source/HorrorGame/Private/first_Person_Character.cpp
+++ b/Source/HorrorGame/Private/first_Person_Character.cpp
@@ -44,6 +44,15 @@ Afirst_Person_Character::Afirst_Person_Character()
     PostProcessComponent->SetupAttachment(RootComponent);
     PostProcessComponent->bUnbound = true;
 
+    // flashlight component
+    Flashlight = CreateDefaultSubobject<USpotLightComponent>(TEXT("Flashlight"));
+    Flashlight->SetupAttachment(cam);
+    Flashlight->SetVisibility(false);
+    Flashlight->SetIntensity(5000.0f);
+    Flashlight->SetInnerConeAngle(20.0f);
+    Flashlight->SetOuterConeAngle(35.0f);
+    Flashlight->SetAttenuationRadius(1000.0f);
+
     //basic movements speeds
     DefaultMaxWalkingSpeed = 150.0f;
     SprintSpeedMultiplier = 1.45f;
@@ -263,6 +272,9 @@ void Afirst_Person_Character::SetupPlayerInputComponent(UInputComponent* PlayerI
     // INTERACT INPUT (e)
     PlayerInputComponent->BindAction("InteractTest", IE_Pressed, this, &Afirst_Person_Character::Interact);
 
+    // FLASHLIGHT INPUT (f)
+    PlayerInputComponent->BindAction("ToggleFlashlight", IE_Pressed, this, &Afirst_Person_Character::ToggleFlashlight);
+
     // PAUSE MENU INPUT (Escape)
     PlayerInputComponent->BindAction("PauseGame", IE_Pressed, this, &Afirst_Person_Character::TogglePause);
 }
@@ -281,6 +293,16 @@ void Afirst_Person_Character::Vertic_Move(float value)
     {
         AddMovementInput(GetActorForwardVector(), value);
     }
+}
+
+void Afirst_Person_Character::ToggleFlashlight()
+{
+    if (!bHasFlashlight || !Flashlight) return;
+
+    bFlashlightOn = !bFlashlightOn;
+    Flashlight->SetVisibility(bFlashlightOn);
+
+    UE_LOG(LogTemp, Log, TEXT("Flashlight toggled: %s"), bFlashlightOn ? TEXT("On") : TEXT("Off"));
 }
 
 void Afirst_Person_Character::TogglePause()

--- a/Source/HorrorGame/Private/first_Person_Character.cpp
+++ b/Source/HorrorGame/Private/first_Person_Character.cpp
@@ -345,32 +345,35 @@ void Afirst_Person_Character::ToggleFlashlight()
 {
     if (CurrentItemTag == "PickupFlashlight")
     {
-        // Show battery UI when flashlight is held
+        if (CurrentBattery > 0)
+        {
+            bFlashlightOn = !bFlashlightOn;
+        }
+       
+        Flashlight->SetVisibility(bFlashlightOn);
+
         if (BatteryWidget)
         {
-            BatteryWidget->SetVisibility(ESlateVisibility::Visible);
-        }
-
-        if (!bFlashlightOn && CurrentBattery > 0)
-        {
-            bFlashlightOn = true;
-            Flashlight->SetVisibility(true);
-        }
-        else if (bFlashlightOn)
-        {
-            bFlashlightOn = false;
-            Flashlight->SetVisibility(false);
+            BatteryWidget->SetVisibility(bFlashlightOn ? ESlateVisibility::Visible : ESlateVisibility::Hidden);
         }
 
         if (CurrentBattery <= 0)
         {
             bFlashlightOn = false;
             Flashlight->SetVisibility(false);
+            if (BatteryWidget)
+            {
+                BatteryWidget->SetVisibility(ESlateVisibility::Hidden);
+            }
         }
-
         UpdateBatteryUI();
     }
-    else
+
+}
+
+void Afirst_Person_Character::AutoTurnOffFlashlight()
+{ 
+    if (CurrentItemTag != "PickupFlashlight")
     {
         // Hide battery UI when flashlight is no longer equipped
         if (BatteryWidget)
@@ -381,8 +384,29 @@ void Afirst_Person_Character::ToggleFlashlight()
         // Also turn flashlight off
         bFlashlightOn = false;
         Flashlight->SetVisibility(false);
+        UE_LOG(LogTemp, Log, TEXT("Flashlight forced OFF because it's not being held"));
     }
 }
+
+void Afirst_Person_Character::RemoveItemFromInventory()
+{
+    Inventory.RemoveAt(CurrentIndex);
+    InventoryTags.RemoveAt(CurrentIndex);
+
+    if (Inventory.Num() > 0)
+    {
+        CurrentIndex = CurrentIndex % Inventory.Num();
+        CurrentItem = Inventory[CurrentIndex];
+        CurrentItemTag = InventoryTags[CurrentIndex];
+    }
+    else
+    {
+        CurrentIndex = 0;
+        CurrentItem = nullptr;
+        CurrentItemTag = NAME_None;
+    }
+}
+
 
 void Afirst_Person_Character::UpdateBatteryUI()
 {
@@ -418,29 +442,8 @@ void Afirst_Person_Character::DropCurrentItem()
         AActor* SpawnedActor = World->SpawnActor<AActor>(CurrentItem, SpawnLocation, SpawnRotation, SpawnParams);
         SpawnedActor->SetActorScale3D(StoredItemScale);
 
-        Inventory.RemoveAt(CurrentIndex);
-        InventoryTags.RemoveAt(CurrentIndex);
-
-        if (Inventory.Num() > 0)
-        {
-            CurrentIndex = CurrentIndex % Inventory.Num();
-            CurrentItem = Inventory[CurrentIndex];
-            CurrentItemTag = InventoryTags[CurrentIndex];
-        }
-        else
-        {
-            CurrentIndex = 0;
-            CurrentItem = nullptr;
-            CurrentItemTag = NAME_None;
-        }
-
-        ToggleFlashlight();
-    }
-
-    // Hide battery UI if we dropped the flashlight
-    if (BatteryWidget && CurrentItemTag != "PickupFlashlight")
-    {
-        BatteryWidget->SetVisibility(ESlateVisibility::Hidden);
+        RemoveItemFromInventory();
+        AutoTurnOffFlashlight();
     }
 }
 
@@ -472,19 +475,7 @@ void Afirst_Person_Character::ScrollInventory(float AxisValue)
         }
     }
     
-    ToggleFlashlight();
-
-    if (BatteryWidget)
-    {
-        if (CurrentItemTag == "PickupFlashlight")
-        {
-            BatteryWidget->SetVisibility(ESlateVisibility::Visible);
-        }
-        else
-        {
-            BatteryWidget->SetVisibility(ESlateVisibility::Hidden);
-        }
-    }
+    AutoTurnOffFlashlight();
 }
 
 void Afirst_Person_Character::TogglePause()

--- a/Source/HorrorGame/Private/first_Person_Character.cpp
+++ b/Source/HorrorGame/Private/first_Person_Character.cpp
@@ -48,7 +48,7 @@ Afirst_Person_Character::Afirst_Person_Character()
     Flashlight = CreateDefaultSubobject<USpotLightComponent>(TEXT("Flashlight"));
     Flashlight->SetupAttachment(cam);
     Flashlight->SetVisibility(false);
-    Flashlight->SetIntensity(5000.0f);
+    Flashlight->SetIntensity(2500.0f);
     Flashlight->SetInnerConeAngle(20.0f);
     Flashlight->SetOuterConeAngle(35.0f);
     Flashlight->SetAttenuationRadius(1000.0f);
@@ -128,7 +128,17 @@ void Afirst_Person_Character::BeginPlay()
         {
             CrosshairWidget->AddToViewport(1);
         }
-    }   
+    }  
+
+    if (BatteryWidgetClass)
+    {
+        BatteryWidget = CreateWidget<UUserWidget>(GetWorld()->GetFirstPlayerController(), BatteryWidgetClass);
+        if (BatteryWidget)
+        {
+            BatteryWidget->AddToViewport();
+            BatteryWidget->SetVisibility(ESlateVisibility::Hidden); // hides it initially
+        }
+    }
 
     // NEW LOOP INIT LOGIC
     UHorrorGameInstance* GameInstance = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(this));
@@ -236,6 +246,34 @@ void Afirst_Person_Character::Tick(float DeltaTime)
         Settings.bOverride_VignetteIntensity = true;
         Settings.VignetteIntensity = FMath::FInterpTo(Settings.VignetteIntensity, TargetVignetteIntensity, DeltaTime, VFXTransitionSpeed);
     }
+
+    // BATTERY DRAIN LOGIC
+    if (bFlashlightOn)
+    {
+        BatteryDrainTimer += DeltaTime;
+
+        // Drain every 5 seconds (adjust interval here)
+        if (BatteryDrainTimer >= 5.0f)
+        {
+            BatteryDrainTimer = 0.f;
+
+            if (CurrentBattery > 0)
+            {
+                CurrentBattery--;
+
+                // Turn off flashlight if empty
+                if (CurrentBattery <= 0)
+                {
+                    CurrentBattery = 0;
+                    bFlashlightOn = false;
+                    Flashlight->SetVisibility(false);
+                    UE_LOG(LogTemp, Warning, TEXT("Battery depleted. Flashlight OFF"));
+                }
+
+                UpdateBatteryUI(); // custom function to update widget
+            }
+        }
+    }
 }
 
 float Afirst_Person_Character::GetTargetFOV() const
@@ -307,16 +345,62 @@ void Afirst_Person_Character::ToggleFlashlight()
 {
     if (CurrentItemTag == "PickupFlashlight")
     {
-        bFlashlightOn = !bFlashlightOn;
-        Flashlight->SetVisibility(bFlashlightOn);
-        UE_LOG(LogTemp, Log, TEXT("Flashlight %s"), bFlashlightOn ? TEXT("ON") : TEXT("OFF"));
+        // Show battery UI when flashlight is held
+        if (BatteryWidget)
+        {
+            BatteryWidget->SetVisibility(ESlateVisibility::Visible);
+        }
+
+        if (!bFlashlightOn && CurrentBattery > 0)
+        {
+            bFlashlightOn = true;
+            Flashlight->SetVisibility(true);
+        }
+        else if (bFlashlightOn)
+        {
+            bFlashlightOn = false;
+            Flashlight->SetVisibility(false);
+        }
+
+        if (CurrentBattery <= 0)
+        {
+            bFlashlightOn = false;
+            Flashlight->SetVisibility(false);
+        }
+
+        UpdateBatteryUI();
     }
-    
-    else if (bFlashlightOn)
+    else
     {
+        // Hide battery UI when flashlight is no longer equipped
+        if (BatteryWidget)
+        {
+            BatteryWidget->SetVisibility(ESlateVisibility::Hidden);
+        }
+
+        // Also turn flashlight off
         bFlashlightOn = false;
         Flashlight->SetVisibility(false);
-        UE_LOG(LogTemp, Log, TEXT("Flashlight forced OFF because it's not being held"));
+    }
+}
+
+void Afirst_Person_Character::UpdateBatteryUI()
+{
+    if (BatteryWidget)
+    {
+        UFunction* UpdateFunc = BatteryWidget->FindFunction(FName("UpdateBatteryBars"));
+        if (UpdateFunc)
+        {
+            struct FBatteryParams
+            {
+                int32 BatteryLevel;
+            };
+
+            FBatteryParams Params;
+            Params.BatteryLevel = CurrentBattery;
+
+            BatteryWidget->ProcessEvent(UpdateFunc, &Params);
+        }
     }
 }
 
@@ -352,6 +436,12 @@ void Afirst_Person_Character::DropCurrentItem()
 
         ToggleFlashlight();
     }
+
+    // Hide battery UI if we dropped the flashlight
+    if (BatteryWidget && CurrentItemTag != "PickupFlashlight")
+    {
+        BatteryWidget->SetVisibility(ESlateVisibility::Hidden);
+    }
 }
 
 void Afirst_Person_Character::ScrollInventory(float AxisValue)
@@ -383,6 +473,18 @@ void Afirst_Person_Character::ScrollInventory(float AxisValue)
     }
     
     ToggleFlashlight();
+
+    if (BatteryWidget)
+    {
+        if (CurrentItemTag == "PickupFlashlight")
+        {
+            BatteryWidget->SetVisibility(ESlateVisibility::Visible);
+        }
+        else
+        {
+            BatteryWidget->SetVisibility(ESlateVisibility::Hidden);
+        }
+    }
 }
 
 void Afirst_Person_Character::TogglePause()
@@ -421,21 +523,29 @@ void Afirst_Person_Character::ApplyHeadBobbing(float DeltaTime) //Head-Bobbing f
     if (!bEnableHeadBobbing || !cam) return;
 
     float Speed = GetVelocity().Size();
-    //reduce bob when walking
-    float BobbingFactor = 1.0f; //default bobbing factor
-    if (Speed > 10.0f && Speed < 150.0f) //bob when walking
+    float TargetBobbingFactor = 0.0f;
+
+    // Determine target factor based on state
+    if (bIsSprinting)
     {
-        BobbingFactor = 0.5f; //reduce bob intensity when walking
+        TargetBobbingFactor = 1.5f; // intense sprint bob
     }
-    else if (Speed >= 150.0f) //more bob when sprint
+    else if (Speed > 10.0f)
     {
-        BobbingFactor = 1.0f;
+        TargetBobbingFactor = 0.5f; // subtle walking bob
     }
+    else
+    {
+        TargetBobbingFactor = 0.0f; // idle
+    }
+
+    // Smooth interpolation
+    CurrentBobbingFactor = FMath::FInterpTo(CurrentBobbingFactor, TargetBobbingFactor, DeltaTime, 5.0f); // tweak 5.0f as smoothing speed
 
     if (Speed > 10.0f)
     {
         BobbingTime += DeltaTime * BobbingSpeed;
-        float BobbingOffset = FMath::Sin(BobbingTime) * BobbingAmount * BobbingFactor;
+        float BobbingOffset = FMath::Sin(BobbingTime) * BobbingAmount * CurrentBobbingFactor;
 
         //reduce bob when crouching
         if (bWantsToCrouch)

--- a/Source/HorrorGame/Private/first_Person_Character.cpp
+++ b/Source/HorrorGame/Private/first_Person_Character.cpp
@@ -52,6 +52,7 @@ Afirst_Person_Character::Afirst_Person_Character()
     Flashlight->SetInnerConeAngle(20.0f);
     Flashlight->SetOuterConeAngle(35.0f);
     Flashlight->SetAttenuationRadius(1000.0f);
+    bFlashlightOn = false;
 
     //basic movements speeds
     DefaultMaxWalkingSpeed = 150.0f;
@@ -279,6 +280,8 @@ void Afirst_Person_Character::SetupPlayerInputComponent(UInputComponent* PlayerI
 
     // FLASHLIGHT INPUT (f)
     PlayerInputComponent->BindAction("ToggleFlashlight", IE_Pressed, this, &Afirst_Person_Character::ToggleFlashlight);
+    PlayerInputComponent->BindAction("DropItem", IE_Pressed, this, &Afirst_Person_Character::DropCurrentItem);
+    PlayerInputComponent->BindAxis("ScrollInventory", this, &Afirst_Person_Character::ScrollInventory);
 
     // PAUSE MENU INPUT (Escape)
     PlayerInputComponent->BindAction("PauseGame", IE_Pressed, this, &Afirst_Person_Character::TogglePause);
@@ -302,12 +305,84 @@ void Afirst_Person_Character::Vertic_Move(float value)
 
 void Afirst_Person_Character::ToggleFlashlight()
 {
-    if (!bHasFlashlight || !Flashlight) return;
+    if (CurrentItemTag == "PickupFlashlight")
+    {
+        bFlashlightOn = !bFlashlightOn;
+        Flashlight->SetVisibility(bFlashlightOn);
+        UE_LOG(LogTemp, Log, TEXT("Flashlight %s"), bFlashlightOn ? TEXT("ON") : TEXT("OFF"));
+    }
+    
+    else if (bFlashlightOn)
+    {
+        bFlashlightOn = false;
+        Flashlight->SetVisibility(false);
+        UE_LOG(LogTemp, Log, TEXT("Flashlight forced OFF because it's not being held"));
+    }
+}
 
-    bFlashlightOn = !bFlashlightOn;
-    Flashlight->SetVisibility(bFlashlightOn);
+void Afirst_Person_Character::DropCurrentItem()
+{
+    if (!CurrentItem) return;
 
-    UE_LOG(LogTemp, Log, TEXT("Flashlight toggled: %s"), bFlashlightOn ? TEXT("On") : TEXT("Off"));
+    FVector SpawnLocation = GetActorLocation() + GetActorForwardVector() * 150.f;
+    FRotator SpawnRotation = GetActorRotation();
+
+    UWorld* World = GetWorld();
+    if (World)
+    {
+        FActorSpawnParameters SpawnParams;
+        AActor* SpawnedActor = World->SpawnActor<AActor>(CurrentItem, SpawnLocation, SpawnRotation, SpawnParams);
+        SpawnedActor->SetActorScale3D(StoredItemScale);
+
+        Inventory.RemoveAt(CurrentIndex);
+        InventoryTags.RemoveAt(CurrentIndex);
+
+        if (Inventory.Num() > 0)
+        {
+            CurrentIndex = CurrentIndex % Inventory.Num();
+            CurrentItem = Inventory[CurrentIndex];
+            CurrentItemTag = InventoryTags[CurrentIndex];
+        }
+        else
+        {
+            CurrentIndex = 0;
+            CurrentItem = nullptr;
+            CurrentItemTag = NAME_None;
+        }
+
+        ToggleFlashlight();
+    }
+}
+
+void Afirst_Person_Character::ScrollInventory(float AxisValue)
+{
+    if (Inventory.Num() == 0 || FMath::IsNearlyZero(AxisValue)) return;
+
+    int32 TotalSlots = Inventory.Num() + 1;
+
+    CurrentIndex = (CurrentIndex + (AxisValue > 0 ? 1 : -1) + TotalSlots) % TotalSlots;
+
+    if (CurrentIndex == Inventory.Num())
+    {
+        CurrentItem = nullptr;
+        CurrentItemTag = NAME_None;
+        UE_LOG(LogTemp, Log, TEXT("Held item: None"));
+    }
+    else 
+    {
+        CurrentItem = (Inventory.IsValidIndex(CurrentIndex)) ? Inventory[CurrentIndex] : nullptr; 
+        CurrentItemTag = InventoryTags.IsValidIndex(CurrentIndex) ? InventoryTags[CurrentIndex] : NAME_None;
+        if (CurrentItem)
+        {
+            UE_LOG(LogTemp, Log, TEXT("Held item: %s"), *CurrentItem->GetName());
+        }
+        else
+        {
+            UE_LOG(LogTemp, Warning, TEXT("Held item is null (unexpected)"));
+        }
+    }
+    
+    ToggleFlashlight();
 }
 
 void Afirst_Person_Character::TogglePause()

--- a/Source/HorrorGame/Private/interaction_System.cpp
+++ b/Source/HorrorGame/Private/interaction_System.cpp
@@ -73,6 +73,7 @@ void Ainteraction_System::InitInteractionFunctionMap()
     Interaction_Functions.Add(FName(TEXT("ExitDoor")), &Ainteraction_System::CompleteLoopDoor);
     Interaction_Functions.Add(FName(TEXT("Loop1Key")), &Ainteraction_System::CollectLoop1Key);
     Interaction_Functions.Add("TeleportToMainRoom", &Ainteraction_System::TeleportUsingDataTable); // uses the DataTable
+    Interaction_Functions.Add(FName(TEXT("PickupFlashlight")), &Ainteraction_System::PickupFlashlight);
 
 }
 
@@ -151,6 +152,22 @@ void Ainteraction_System::WidgetPrompt(Afirst_Person_Character* Character, AActo
 
         Widget->SetVisibility(Visibility);
     }
+}
+
+void Ainteraction_System::PickupFlashlight(Afirst_Person_Character* Character, AActor* HitActor)
+{
+    if (!Character || !HitActor) return;
+
+    Character->bHasFlashlight = true;
+
+    if (Character->Flashlight)
+    {
+        Character->Flashlight->SetVisibility(false);
+        Character->bFlashlightOn = false;
+    }
+
+    HitActor->Destroy();
+    UE_LOG(LogTemp, Log, TEXT("Flashlight picked up."));
 }
 
 void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AActor* HitActor)

--- a/Source/HorrorGame/Private/interaction_System.cpp
+++ b/Source/HorrorGame/Private/interaction_System.cpp
@@ -168,6 +168,12 @@ void Ainteraction_System::PickupFlashlight(Afirst_Person_Character* Character, A
 
     HitActor->Destroy();
     UE_LOG(LogTemp, Log, TEXT("Flashlight picked up."));
+
+    UHorrorGameInstance* GI = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(Character));
+    if (GI && HitActor->Tags.Num() > 0)
+    {
+        GI->MarkTagInteracted(HitActor->Tags[0]);
+    }
 }
 
 void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AActor* HitActor)
@@ -262,6 +268,11 @@ void Ainteraction_System::CollectLoop1Key(Afirst_Person_Character* Character, AA
         GI->bLoop1Complete = true;
         HitActor->Destroy();
         UE_LOG(LogTemp, Warning, TEXT("Loop 1 Key Collected!"));
+
+        if (HitActor->Tags.Num() > 0)
+        {
+            GI->MarkTagInteracted(HitActor->Tags[0]);
+        }
     }
 }
 

--- a/Source/HorrorGame/Private/interaction_System.cpp
+++ b/Source/HorrorGame/Private/interaction_System.cpp
@@ -46,7 +46,6 @@ void Ainteraction_System::Tick(float DeltaTime)
     }
 
     LastHitActor = Current;
-    UE_LOG(LogTemp, Log, TEXT("Tick Trace hit: nothing"));
 }
 
 AActor* Ainteraction_System::LineTraceFromCamera(Afirst_Person_Character* Character, FHitResult& Hit)
@@ -73,7 +72,7 @@ void Ainteraction_System::InitInteractionFunctionMap()
     Interaction_Functions.Add(FName(TEXT("ExitDoor")), &Ainteraction_System::CompleteLoopDoor);
     Interaction_Functions.Add(FName(TEXT("Loop1Key")), &Ainteraction_System::CollectLoop1Key);
     Interaction_Functions.Add("TeleportToMainRoom", &Ainteraction_System::TeleportUsingDataTable); // uses the DataTable
-    Interaction_Functions.Add(FName(TEXT("PickupFlashlight")), &Ainteraction_System::PickupFlashlight);
+    Interaction_Functions.Add(FName(TEXT("Pickup_Object")), &Ainteraction_System::Pickup_Object);
 
 }
 
@@ -116,7 +115,7 @@ void Ainteraction_System::Perform_Interaction(Afirst_Person_Character* Character
         if (Row)
         {
             const FName& FunctionName = Row->Interactable_Function;
-
+            UE_LOG(LogTemp, Log, TEXT("Found function: %s"), *FunctionName.ToString());
             if (Interaction_Functions.Contains(FunctionName))
             {
                 UE_LOG(LogTemp, Log, TEXT("Performing interaction for tag '%s' using function '%s'"), *Tag.ToString(), *FunctionName.ToString());
@@ -154,31 +153,31 @@ void Ainteraction_System::WidgetPrompt(Afirst_Person_Character* Character, AActo
     }
 }
 
-void Ainteraction_System::PickupFlashlight(Afirst_Person_Character* Character, AActor* HitActor)
+
+void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AActor* HitActor)
 {
     if (!Character || !HitActor) return;
 
-    Character->bHasFlashlight = true;
+    TSubclassOf<AActor> Item = HitActor->GetClass();
+    FName Tag = HitActor->Tags.IsValidIndex(0) ? HitActor->Tags[0] : NAME_None;
+    Character->StoredItemScale = HitActor->GetActorScale3D();
 
-    if (Character->Flashlight)
-    {
-        Character->Flashlight->SetVisibility(false);
-        Character->bFlashlightOn = false;
-    }
+    Character->Inventory.Add(Item);
+    Character->InventoryTags.Add(Tag);
 
-    HitActor->Destroy();
-    UE_LOG(LogTemp, Log, TEXT("Flashlight picked up."));
+    Character->CurrentItem = Item;
+    Character->CurrentItemTag = Tag;
+    Character->CurrentIndex = Character->Inventory.Num() - 1;
+
+    UE_LOG(LogTemp, Log, TEXT("Item '%s' added to inventory."), *HitActor->GetName());
 
     UHorrorGameInstance* GI = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(Character));
     if (GI && HitActor->Tags.Num() > 0)
     {
         GI->MarkTagInteracted(HitActor->Tags[0]);
     }
-}
 
-void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AActor* HitActor)
-{
-    UE_LOG(LogTemp, Log, TEXT("Picked up an object!"));
+    HitActor->Destroy();
 }
 
 void Ainteraction_System::TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor)

--- a/Source/HorrorGame/Private/interaction_System.cpp
+++ b/Source/HorrorGame/Private/interaction_System.cpp
@@ -73,6 +73,7 @@ void Ainteraction_System::InitInteractionFunctionMap()
     Interaction_Functions.Add(FName(TEXT("Loop1Key")), &Ainteraction_System::CollectLoop1Key);
     Interaction_Functions.Add("TeleportToMainRoom", &Ainteraction_System::TeleportUsingDataTable); // uses the DataTable
     Interaction_Functions.Add(FName(TEXT("Pickup_Object")), &Ainteraction_System::Pickup_Object);
+    Interaction_Functions.Add(FName(TEXT("RestoreFlashlightBattery")), &Ainteraction_System::RestoreFlashlightBattery);
 
 }
 
@@ -170,6 +171,24 @@ void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AAct
     Character->CurrentIndex = Character->Inventory.Num() - 1;
 
     UE_LOG(LogTemp, Log, TEXT("Item '%s' added to inventory."), *HitActor->GetName());
+
+    // if flashlight is picked up, start with 2 battery bars
+    if (Tag == "PickupFlashlight")
+    {
+        // Only set to 2 bars if not previously picked up
+        if (!Character->bHasPickedUpFlashlight)
+        {
+            Character->CurrentBattery = 2;
+            Character->bHasPickedUpFlashlight = true;
+            UE_LOG(LogTemp, Log, TEXT("First flashlight pickup. Battery set to 2 bars."));
+        }
+        else
+        {
+            UE_LOG(LogTemp, Log, TEXT("Flashlight re-picked up. Keeping previous battery level: %d"), Character->CurrentBattery);
+        }
+
+        Character->UpdateBatteryUI();
+    }
 
     UHorrorGameInstance* GI = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(Character));
     if (GI && HitActor->Tags.Num() > 0)
@@ -273,5 +292,20 @@ void Ainteraction_System::CollectLoop1Key(Afirst_Person_Character* Character, AA
             GI->MarkTagInteracted(HitActor->Tags[0]);
         }
     }
+}
+
+void Ainteraction_System::RestoreFlashlightBattery(Afirst_Person_Character* Character, AActor* HitActor)
+{
+    if (!Character || !HitActor) return;
+
+    // Restore battery to full
+    Character->CurrentBattery = Character->MaxBattery;
+
+    // update UI immediately
+    Character->UpdateBatteryUI();
+
+    UE_LOG(LogTemp, Warning, TEXT("Battery picked up. Flashlight fully recharged!"));
+
+    HitActor->Destroy();
 }
 

--- a/Source/HorrorGame/Private/interaction_System.cpp
+++ b/Source/HorrorGame/Private/interaction_System.cpp
@@ -41,7 +41,6 @@ void Ainteraction_System::Tick(float DeltaTime)
 
     if (Current)
     {
-        UE_LOG(LogTemp, Log, TEXT("Tick Trace hit: %s"), *Current->GetName());
         WidgetPrompt(Character, Current, true);
     }
 
@@ -70,7 +69,6 @@ void Ainteraction_System::InitInteractionFunctionMap()
 {
     Interaction_Functions.Add(FName(TEXT("OpenDoor")), &Ainteraction_System::TeleportUsingDataTable);
     Interaction_Functions.Add(FName(TEXT("ExitDoor")), &Ainteraction_System::CompleteLoopDoor);
-    Interaction_Functions.Add(FName(TEXT("Loop1Key")), &Ainteraction_System::CollectLoop1Key);
     Interaction_Functions.Add("TeleportToMainRoom", &Ainteraction_System::TeleportUsingDataTable); // uses the DataTable
     Interaction_Functions.Add(FName(TEXT("Pickup_Object")), &Ainteraction_System::Pickup_Object);
     Interaction_Functions.Add(FName(TEXT("RestoreFlashlightBattery")), &Ainteraction_System::RestoreFlashlightBattery);
@@ -197,6 +195,7 @@ void Ainteraction_System::Pickup_Object(Afirst_Person_Character* Character, AAct
     }
 
     HitActor->Destroy();
+    Character->AutoTurnOffFlashlight();
 }
 
 void Ainteraction_System::TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor)
@@ -243,6 +242,17 @@ void Ainteraction_System::CompleteLoopDoor(Afirst_Person_Character* Character, A
     if (!Character || !HitActor) return;
 
     UHorrorGameInstance* GI = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(Character));
+
+    if (Character->CurrentItemTag != "Loop1Key")
+    {
+        UE_LOG(LogTemp, Warning, TEXT("You must be holding the key to unlock the door."));
+        return;
+    }
+    else
+    {
+        GI->bLoop1Complete = true;
+    }
+
     if (!GI) return;
 
     int32 CurrentLoop = GI->GetLoopIndex();
@@ -266,32 +276,16 @@ void Ainteraction_System::CompleteLoopDoor(Afirst_Person_Character* Character, A
 
     GI->AdvanceLoop();
 
+    Character->RemoveItemFromInventory();
+
     UE_LOG(LogTemp, Warning, TEXT("Loop %d completed! Now entering Loop %d."), CurrentLoop, GI->GetLoopIndex());
 }
+
 
 
 void Ainteraction_System::View_Note(Afirst_Person_Character* Character, AActor* Hit_Actor)
 {
     UE_LOG(LogTemp, Log, TEXT("Viewed a note!"));
-}
-
-// Key interaction for loop 1
-void Ainteraction_System::CollectLoop1Key(Afirst_Person_Character* Character, AActor* HitActor)
-{
-    if (!Character || !HitActor) return;
-
-    UHorrorGameInstance* GI = Cast<UHorrorGameInstance>(UGameplayStatics::GetGameInstance(Character));
-    if (GI && GI->GetLoopIndex() == 1)
-    {
-        GI->bLoop1Complete = true;
-        HitActor->Destroy();
-        UE_LOG(LogTemp, Warning, TEXT("Loop 1 Key Collected!"));
-
-        if (HitActor->Tags.Num() > 0)
-        {
-            GI->MarkTagInteracted(HitActor->Tags[0]);
-        }
-    }
 }
 
 void Ainteraction_System::RestoreFlashlightBattery(Afirst_Person_Character* Character, AActor* HitActor)

--- a/Source/HorrorGame/Public/HorrorGameInstance.h
+++ b/Source/HorrorGame/Public/HorrorGameInstance.h
@@ -85,6 +85,15 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void SaveGameProgress();
 
+	UPROPERTY()
+	TSet<FName> InteractedTags;
+
+	UFUNCTION(BlueprintCallable)
+	void MarkTagInteracted(FName Tag) { InteractedTags.Add(Tag); }
+
+	UFUNCTION(BlueprintCallable)
+	bool HasInteractedWith(FName Tag) const { return InteractedTags.Contains(Tag); }
+
 	UFUNCTION(BlueprintCallable)
 	bool LoadGameProgress();
 

--- a/Source/HorrorGame/Public/HorrorSaveGame.h
+++ b/Source/HorrorGame/Public/HorrorSaveGame.h
@@ -15,6 +15,16 @@ class HORRORGAME_API UHorrorSaveGame : public USaveGame
 	GENERATED_BODY()
 
 public:
+
+    UPROPERTY()
+    FVector PlayerLocation;
+
+    UPROPERTY()
+    FRotator PlayerRotation;
+
+    UPROPERTY()
+    TArray<FName> InteractedTags;
+
     UPROPERTY()
     int32 SavedLoopIndex;
 

--- a/Source/HorrorGame/Public/HorrorSaveGame.h
+++ b/Source/HorrorGame/Public/HorrorSaveGame.h
@@ -29,6 +29,12 @@ public:
     int32 SavedLoopIndex;
 
     UPROPERTY()
+    int32 SavedBatteryLevel;
+
+    UPROPERTY()
+    bool bHasPickedUpFlashlight = false;
+
+    UPROPERTY()
     bool bLoop1Complete;
 
     UPROPERTY()

--- a/Source/HorrorGame/Public/first_Person_Character.h
+++ b/Source/HorrorGame/Public/first_Person_Character.h
@@ -7,6 +7,7 @@
 #include "Components/InputComponent.h"
 #include "Camera/CameraComponent.h"
 #include "Components/PostProcessComponent.h"
+#include "Components/SpotLightComponent.h"
 #include "Blueprint/UserWidget.h"
 #include "PauseManager.h"
 #include "interaction_System.h"
@@ -53,6 +54,17 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Transition")
     float TeleportDelayTime = 0.6f;
 
+    // FLASHLIGHT FEATURE
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
+    class USpotLightComponent* Flashlight;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
+    bool bHasFlashlight = false;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
+    bool bFlashlightOn = false;
+
+    void ToggleFlashlight();
 
 private:
     // FOV CAMERA TRANSITION FEATURE

--- a/Source/HorrorGame/Public/first_Person_Character.h
+++ b/Source/HorrorGame/Public/first_Person_Character.h
@@ -58,7 +58,24 @@ public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
     class USpotLightComponent* Flashlight;
 
+    UPROPERTY(BlueprintReadWrite)
+    bool bHasPickedUpFlashlight = false;
+
     bool bFlashlightOn;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Flashlight")
+    int32 MaxBattery = 5;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Flashlight")
+    int32 CurrentBattery = 5;
+
+    UFUNCTION()
+    void UpdateBatteryUI();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UI")
+    TSubclassOf<UUserWidget> BatteryWidgetClass;
+
+    UUserWidget* BatteryWidget;
 
     // INVENTORY SYSTEM
     UPROPERTY()
@@ -99,6 +116,9 @@ private:
     UPROPERTY()
     UUserWidget* CrosshairWidget;
 
+    // flashlight drain
+    float BatteryDrainTimer = 0.f;
+
     // PAUSE MENU UI
     UPROPERTY()
     APauseManager* PauseManager;
@@ -117,6 +137,8 @@ private:
     // HEAD-BOB FEATURE
     UPROPERTY(EditAnywhere, Category = "HeadBobbing")
     bool bEnableHeadBobbing = true; // toggle head bobbing on/off
+
+    float CurrentBobbingFactor = 0.0f;
 
     UPROPERTY(EditAnywhere, Category = "HeadBobbing")
     float BobbingSpeed = 10.0f;

--- a/Source/HorrorGame/Public/first_Person_Character.h
+++ b/Source/HorrorGame/Public/first_Person_Character.h
@@ -92,7 +92,9 @@ public:
     int32 CurrentIndex = 0;
 
     void ToggleFlashlight();
+    void AutoTurnOffFlashlight();
     void DropCurrentItem();
+    void RemoveItemFromInventory();
     void ScrollInventory(float Value);
 
 private:

--- a/Source/HorrorGame/Public/first_Person_Character.h
+++ b/Source/HorrorGame/Public/first_Person_Character.h
@@ -55,16 +55,28 @@ public:
     float TeleportDelayTime = 0.6f;
 
     // FLASHLIGHT FEATURE
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
     class USpotLightComponent* Flashlight;
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
-    bool bHasFlashlight = false;
+    bool bFlashlightOn;
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flashlight")
-    bool bFlashlightOn = false;
+    // INVENTORY SYSTEM
+    UPROPERTY()
+    TArray<TSubclassOf<AActor>> Inventory;
+
+    UPROPERTY()
+    TArray<FName> InventoryTags;
+
+    UPROPERTY()
+    FVector StoredItemScale;
+    
+    FName CurrentItemTag = NAME_None;
+    TSubclassOf<AActor> CurrentItem = nullptr;
+    int32 CurrentIndex = 0;
 
     void ToggleFlashlight();
+    void DropCurrentItem();
+    void ScrollInventory(float Value);
 
 private:
     // FOV CAMERA TRANSITION FEATURE

--- a/Source/HorrorGame/Public/interaction_System.h
+++ b/Source/HorrorGame/Public/interaction_System.h
@@ -8,6 +8,7 @@
 #include "interaction_System.generated.h"
 
 class Afirst_Person_Character;
+class UWidgetComponent;
 
 UCLASS()
 class HORRORGAME_API Ainteraction_System : public AActor
@@ -17,6 +18,8 @@ class HORRORGAME_API Ainteraction_System : public AActor
 public:	
 	// Sets default values for this actor's properties
 	Ainteraction_System();
+
+	virtual void Tick(float DeltaTime) override;
 
 	UFUNCTION()
 	void Interact(Afirst_Person_Character* Character);
@@ -56,12 +59,13 @@ private:
 	void CompleteLoopDoor(Afirst_Person_Character* Character, AActor* HitActor);
 
 	void TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor);
-
-
+	void WidgetPrompt(Afirst_Person_Character* Character, AActor* HitActor, bool Visibility);
 
 	// Map of tag -> function pointer
 	TMap<FName, void (Ainteraction_System::*)(Afirst_Person_Character*, AActor*)> Interaction_Functions;
-
 	void InitInteractionFunctionMap();
+
+	AActor* LineTraceFromCamera(Afirst_Person_Character* Character, FHitResult& Hit);
+	AActor* LastHitActor = nullptr;
 
 };

--- a/Source/HorrorGame/Public/interaction_System.h
+++ b/Source/HorrorGame/Public/interaction_System.h
@@ -57,6 +57,7 @@ private:
 	void View_Note(Afirst_Person_Character* Character, AActor* HitActor);
 	void CollectLoop1Key(Afirst_Person_Character* Character, AActor* HitActor);
 	void CompleteLoopDoor(Afirst_Person_Character* Character, AActor* HitActor);
+	void PickupFlashlight(Afirst_Person_Character* Character, AActor* HitActor);
 
 	void TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor);
 	void WidgetPrompt(Afirst_Person_Character* Character, AActor* HitActor, bool Visibility);

--- a/Source/HorrorGame/Public/interaction_System.h
+++ b/Source/HorrorGame/Public/interaction_System.h
@@ -57,7 +57,6 @@ private:
 	void View_Note(Afirst_Person_Character* Character, AActor* HitActor);
 	void CollectLoop1Key(Afirst_Person_Character* Character, AActor* HitActor);
 	void CompleteLoopDoor(Afirst_Person_Character* Character, AActor* HitActor);
-	void PickupFlashlight(Afirst_Person_Character* Character, AActor* HitActor);
 
 	void TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor);
 	void WidgetPrompt(Afirst_Person_Character* Character, AActor* HitActor, bool Visibility);

--- a/Source/HorrorGame/Public/interaction_System.h
+++ b/Source/HorrorGame/Public/interaction_System.h
@@ -55,7 +55,6 @@ private:
 	// Interaction functions
 	void Pickup_Object(Afirst_Person_Character* Character, AActor* HitActor);
 	void View_Note(Afirst_Person_Character* Character, AActor* HitActor);
-	void CollectLoop1Key(Afirst_Person_Character* Character, AActor* HitActor);
 	void CompleteLoopDoor(Afirst_Person_Character* Character, AActor* HitActor);
 	void RestoreFlashlightBattery(Afirst_Person_Character* Character, AActor* HitActor);
 

--- a/Source/HorrorGame/Public/interaction_System.h
+++ b/Source/HorrorGame/Public/interaction_System.h
@@ -57,6 +57,7 @@ private:
 	void View_Note(Afirst_Person_Character* Character, AActor* HitActor);
 	void CollectLoop1Key(Afirst_Person_Character* Character, AActor* HitActor);
 	void CompleteLoopDoor(Afirst_Person_Character* Character, AActor* HitActor);
+	void RestoreFlashlightBattery(Afirst_Person_Character* Character, AActor* HitActor);
 
 	void TeleportUsingDataTable(Afirst_Person_Character* Character, AActor* HitActor);
 	void WidgetPrompt(Afirst_Person_Character* Character, AActor* HitActor, bool Visibility);


### PR DESCRIPTION
Implemented and Re-Added Furniture & Décor, Lighting, and Outdoor Scenery
Implemented and Re-Added the HUD Interaction Widget:
     - Made it so that the player should be line tracing per tick
     - Made the line trace feature a function to reduce redundancy
     - Made a widget prompt function that should hover by any interactable objects
     - Widget prompt only appears when the player is within range and disappear otherwise
     - Widget prompt is also made so that it will always be facing the direction of the player's camera and rotate alone with it
Implemented a Flashlight Feature:
     - Made an interactive flashlight within the game
     - Player can toggle flashlight on/off with 'F'
Implemented and Re-Added the SaveGame/LoadGame Feature:
     - Player is able to save their current exact location and loop level
     - Player is able to reload their save after quitting the game
     - Continue button in the Main Menu is greyed out if the Player doesn't have a current save
Implemented an Inventory System (Code-Based, UI will be added later):
     - Added an Inventory system to the game by using an array
     - The player always start with an empty inventory
     - When picking up an object, player should still be able to switch off to holding nothing
     - Player can only use the item that they are currently holding
     - By pressing G, the player can drop the item they are currently holding back into the world with the same size it was in the 
       world (for now it floats but can be fixed by adding physics later)
     - By using scroll wheel up and down, the player can cycle through the inventory
     - Integrated the previous flashlight feature with the new inventory system
     - Bug fixed many crashes along the way of making the feature
Implemented a Flashlight Battery UI:
     - Made a flashlight battery widget (5 green bars = full battery)
     - Made the battery interactive so the player can fill up battery when needed
     - Flashlight starts at 2 green bars and can pickup battery to go to 5 bars. If player keeps flashlight on, the battery will slowly 
       diminish 
Fixed Various Bugs:
     - Fixed flashlight so it doesn't auto turn on and battery UI should appear and reappear whenever the player scrolls to another 
        item in their inventory
     - Changed key logic and made it an item that can be stored in the inventory and is used to move onto the next level (player 
        needs to be holding the key to unlock the door)